### PR TITLE
Use user's KERAS_BACKEND env variable if set

### DIFF
--- a/python-package/mlbox/encoding/categorical_encoder.py
+++ b/python-package/mlbox/encoding/categorical_encoder.py
@@ -7,7 +7,10 @@ import pandas as pd
 import warnings
 
 import os
-os.environ["KERAS_BACKEND"] = "theano"
+
+# Set the keras backend if not set, default is theano
+if not "KERAS_BACKEND" in os.environ:
+    os.environ["KERAS_BACKEND"] = "theano"
 
 from keras.layers.core import Dense, Reshape, Dropout
 from keras.layers.embeddings import Embedding


### PR DESCRIPTION
This gives the user a way to choose what framework he wants to use.
Default to theano because it's the only one officially required from requirements.txt.

Fixing #9 How to set Keras Backend?