### PR TITLE
Fix setup.py by overriding install command

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -1,7 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import pip
 from setuptools import setup
+from setuptools.command.install import install
+from pip.req import parse_requirements
+
+install_reqs = parse_requirements("./requirements.txt", session=False)
+reqs = [str(ir.req) for ir in install_reqs]
+
+class OverrideInstallCommand(install):
+    def run(self):
+	# Install all requirements
+        for req in reqs:
+            pip.main(["install", req])
+
+	# install MlBox
+        install.run(self)
 
 with open('README.md') as readme_file:
     readme = readme_file.read()
@@ -62,6 +77,7 @@ setup(
                  'mlbox.preprocessing.drift':'mlbox/preprocessing/drift'
                  },
     include_package_data=True,
+    cmdclass={'install': OverrideInstallCommand},
     install_requires=requirements,
     zip_safe=False,
     keywords='mlbox',


### PR DESCRIPTION
Fix #7 overriding the custom install command.
Inspired by https://github.com/scikit-learn/scikit-learn/issues/4164#issuecomment-243259447

Tested with python 2.7 and 3.5
Changes: doesn't compile anymore the different packages.