### PR TITLE
Cancel installation if one package couldn't be installed by pip

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -11,11 +11,22 @@ reqs = [str(ir.req) for ir in install_reqs]
 
 class OverrideInstallCommand(install):
     def run(self):
-	# Install all requirements
-        for req in reqs:
-            pip.main(["install", req])
+        # Install all requirements
+        failed = []
 
-	# install MlBox
+        for req in reqs:
+            if pip.main(["install", req]) == 1:
+                failed.append(req)
+
+        if len(failed) > 0:
+            print("")
+            print("Error installing the following packages:")
+            print(str(failed))
+            print("Please install them manually")
+            print("")
+            return 1
+
+        # install MlBox
         install.run(self)
 
 with open('README.md') as readme_file:


### PR DESCRIPTION
Don't install MLBox if one package can't be installed.
User is warned with the following message:

    Error installing the following packages:
    ['lightgbm==2.0.2']
    Please install them manually

