### PR TITLE
Correct docstring of the get estimator method

### DIFF
--- a/mlbox/model/classification/classifier.py
+++ b/mlbox/model/classification/classifier.py
@@ -396,5 +396,5 @@ class Classifier():
             raise ValueError("You must call the fit function before !")
 
     def get_estimator(self):
-        """Return classfier."""
+        """Return classifier."""
         return copy(self.__classifier)

--- a/mlbox/model/regression/regressor.py
+++ b/mlbox/model/regression/regressor.py
@@ -349,5 +349,5 @@ class Regressor():
             raise ValueError("You must call the fit function before !")
 
     def get_estimator(self):
-        """Return classfier."""
+        """Return classifier."""
         return copy(self.__regressor)


### PR DESCRIPTION
This PR add the missing "i" for class**i**fier in:
* the docstring of the `Classifier.get_estimator()` method (present in `mlbox/model/classification/classifier.py`) 
* the docstring of the `Regressor.get_estimator()` method (present in ` mlbox/model/regression/regressor.py`)

